### PR TITLE
Rename app to vector API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Perplexity API
+# Contributing to vector API
 
-First off, thank you for considering contributing to Perplexity API. It's people like you that make Perplexity API such a great tool.
+First off, thank you for considering contributing to vector API. It's people like you that make vector API such a great tool.
 
 ## How Can I Contribute?
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for Perplexity API. Following these guidelines helps maintainers and the community understand your report, reproduce the behavior, and find related reports.
+This section guides you through submitting a bug report for vector API. Following these guidelines helps maintainers and the community understand your report, reproduce the behavior, and find related reports.
 
 - Explain the problem and include additional details to help maintainers reproduce the problem:
   - Use a clear and descriptive title for the issue to identify the problem.
@@ -14,7 +14,7 @@ This section guides you through submitting a bug report for Perplexity API. Foll
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for Perplexity API, including completely new features and minor improvements to existing functionality.
+This section guides you through submitting an enhancement suggestion for vector API, including completely new features and minor improvements to existing functionality.
 
 - Use a clear and descriptive title for the issue to identify the suggestion.
 - Provide a step-by-step description of the suggested enhancement in as many details as possible.
@@ -22,7 +22,7 @@ This section guides you through submitting an enhancement suggestion for Perplex
 
 ### Your First Code Contribution
 
-Unsure where to begin contributing to Perplexity API? You can start by looking through these `beginner` and `help-wanted` issues:
+Unsure where to begin contributing to vector API? You can start by looking through these `beginner` and `help-wanted` issues:
 
 - `Beginner issues` - issues which should only require a few lines of code, and a test or two.
 - `Help wanted issues` - issues which should be a bit more involved than `beginner` issues.
@@ -31,10 +31,10 @@ Unsure where to begin contributing to Perplexity API? You can start by looking t
 
 The process described here has several goals:
 
-- Maintain Perplexity API's quality
+- Maintain vector API's quality
 - Fix problems that are important to users
-- Engage the community in working toward the best possible Perplexity API
-- Enable a sustainable system for Perplexity API's maintainers to review contributions
+- Engage the community in working toward the best possible vector API
+- Enable a sustainable system for vector API's maintainers to review contributions
 
 Please follow these steps to have your contribution considered by the maintainers:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Perplexity API
+# vector API
 
-Perplexity API is a high-performance FastAPI backend application designed to seamlessly integrate with vector databases, LangChain, HuggingFace, and OpenAI. It uses an OpenAPI spec and Swagger utilizing JSON Schema to provide a robust and scalable backend solution for AI and machine learning applications. 
+vector API is a high-performance FastAPI backend application designed to seamlessly integrate with vector databases, LangChain, HuggingFace, and OpenAI. It uses an OpenAPI spec and Swagger utilizing JSON Schema to provide a robust and scalable backend solution for AI and machine learning applications. 
 
 ![Screenshot 2023-07-31 at 6 22 29 PM](https://github.com/bastosmichael/perplexity/assets/1518708/99b5440a-e6c7-4e9e-a163-94fccae492bd)
 
@@ -14,7 +14,7 @@ Perplexity API is a high-performance FastAPI backend application designed to sea
 
 - **LangChain Integration**: Incorporates LangChain for comprehensive language processing capabilities, helping to effectively understand, analyze, and generate human language data.
 
-- **HuggingFace & OpenAI Integration**: By integrating state-of-the-art AI platforms like HuggingFace and OpenAI, Perplexity API allows leveraging their extensive capabilities in machine learning and artificial intelligence.
+- **HuggingFace & OpenAI Integration**: By integrating state-of-the-art AI platforms like HuggingFace and OpenAI, vector API allows leveraging their extensive capabilities in machine learning and artificial intelligence.
 
 - **Swagger Compatibility**: Supports Swagger, a powerful interface for REST APIs that allows both developers and non-developers to interact with the API’s resources. It provides insightful information about the operations, parameters, responses, and the direct testing of API endpoints within its UI.
 
@@ -24,7 +24,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 ### Prerequisites
 
-You'll need to install the following items before you can use Perplexity API:
+You'll need to install the following items before you can use vector API:
 
 - Python 3.6 or later
 - Poetry (Python dependency management)
@@ -78,7 +78,7 @@ For more advanced usage, please refer to the [`pytest` documentation](https://do
 
 ## Contributing
 
-We welcome contributions to Perplexity API! Please see our [Contributing Guide](CONTRIBUTING.md) for more details.
+We welcome contributions to vector API! Please see our [Contributing Guide](CONTRIBUTING.md) for more details.
 
 ## License
 

--- a/perplexity/main.py
+++ b/perplexity/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Depends
 from perplexity.routers import router
 from perplexity.settings import get_settings
 
-app = FastAPI(title="PerplexityAPI", dependencies=[Depends(get_settings)])
+app = FastAPI(title="vector API", dependencies=[Depends(get_settings)])
 
 # include routers
 app.include_router(router)


### PR DESCRIPTION
## Summary
- rename Perplexity API references to vector API
- update FastAPI title to reflect new name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6871193fbee8832f9b93e08c9cd96d95